### PR TITLE
Implement graph grader with JigsawStack APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Graph Grader
+
+This project is a simple graph grading service built with **Node.js** and **Express**. It uses the [JigsawStack AI APIs](https://jigsawstack.com/docs/api-reference) to detect plotted points and text on an uploaded image of graph paper. Detected regions are highlighted with translucent boxes and the annotated image is returned to the user.
+
+## Features
+
+- Upload an image of a graph via the web interface
+- Detect "star" plots and text labels using JigsawStack's Object Detection API
+- Recognize axis labels and values using the VOCR API
+- Receive the image back with bounding boxes drawn over detected areas
+
+## Setup
+
+1. Install Node.js (version 18 or later is recommended).
+2. Clone this repository and install dependencies:
+   ```bash
+   npm install
+   ```
+3. Create a `.env` file in the project root with your API key from JigsawStack:
+   ```ini
+   JIGSAW_API_KEY=YOUR_API_KEY_HERE
+   ```
+4. Start the server:
+   ```bash
+   npm start
+   ```
+5. Open `http://localhost:3000` in your browser and upload a graph image to test the grader.
+
+## Notes
+
+- API responses are expected to include bounding box information in the format `{x, y, width, height}` for each detection.
+- The server stores uploaded and annotated images in the `uploads/` directory. Annotated images are not automatically deleted.
+- This project uses the following JigsawStack endpoints:
+  - **Object Detection:** `POST https://jigsawstack.com/api/ai/object-detection/v1/detect`
+  - **VOCR (Vision OCR):** `POST https://jigsawstack.com/api/ai/vocr/v1/detect`
+
+The implementation here is a minimal example and may require adjustments depending on the exact API response structure from JigsawStack.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,38 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Hello World</title>
+    <title>Graph Grader</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        #result img { max-width: 100%; height: auto; }
+    </style>
 </head>
 <body>
-    <h1>Hello, world!</h1>
+    <h1>Graph Grader</h1>
+    <form id="uploadForm" enctype="multipart/form-data">
+        <input type="file" name="image" accept="image/*" required>
+        <button type="submit">Upload</button>
+    </form>
+    <div id="result"></div>
+    <script>
+        const form = document.getElementById('uploadForm');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const formData = new FormData(form);
+            const res = await fetch('/grade', { method: 'POST', body: formData });
+            if (res.ok) {
+                const blob = await res.blob();
+                const url = URL.createObjectURL(blob);
+                const img = new Image();
+                img.src = url;
+                const result = document.getElementById('result');
+                result.innerHTML = '';
+                result.appendChild(img);
+            } else {
+                const err = await res.json();
+                alert(err.error || 'Failed to grade image');
+            }
+        });
+    </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "graph-grader",
+  "version": "1.0.0",
+  "description": "Graph grading tool using JigsawStack AI APIs",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1",
+    "axios": "^1.4.0",
+    "jimp": "^0.22.10",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,73 @@
+require('dotenv').config();
+const express = require('express');
+const multer = require('multer');
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const Jimp = require('jimp');
+
+const upload = multer({ dest: 'uploads/' });
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.post('/grade', upload.single('image'), async (req, res) => {
+  if (!req.file) return res.status(400).json({ error: 'No image uploaded' });
+  const imgPath = req.file.path;
+  try {
+    const buffer = fs.readFileSync(imgPath);
+    const base64 = buffer.toString('base64');
+
+    const apiKey = process.env.JIGSAW_API_KEY;
+    const headers = { 'x-api-key': apiKey };
+
+    // Detect stars and text using object detection
+    const detectRes = await axios.post(
+      'https://jigsawstack.com/api/ai/object-detection/v1/detect',
+      { image: base64, objects: ['star', 'text'] },
+      { headers }
+    );
+    const detections = detectRes.data.detections || [];
+
+    // OCR using VOCR API
+    const ocrRes = await axios.post(
+      'https://jigsawstack.com/api/ai/vocr/v1/detect',
+      { image: base64 },
+      { headers }
+    );
+    const texts = ocrRes.data.texts || [];
+
+    // Annotate image
+    const img = await Jimp.read(buffer);
+    const starColor = Jimp.rgbaToInt(255, 0, 0, 80);
+    const textColor = Jimp.rgbaToInt(0, 255, 0, 80);
+    for (const d of detections) {
+      const b = d.bounding_box;
+      const rect = new Jimp(b.width, b.height, starColor);
+      img.composite(rect, b.x, b.y);
+    }
+    for (const t of texts) {
+      const b = t.bounding_box;
+      const rect = new Jimp(b.width, b.height, textColor);
+      img.composite(rect, b.x, b.y);
+    }
+
+    const outPath = path.join('uploads', `annotated-${req.file.filename}.png`);
+    await img.writeAsync(outPath);
+    res.sendFile(path.resolve(outPath), () => {
+      fs.unlinkSync(imgPath);
+      // keep annotated image
+    });
+  } catch (err) {
+    console.error(err);
+    fs.unlinkSync(imgPath);
+    res.status(500).json({ error: 'Failed to process image' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express server using JigsawStack object detection and VOCR
- draw translucent boxes around detected stars and text
- provide a simple HTML interface for image uploads
- document setup steps and API endpoints in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6878cf058a748327ad9ee9a523cebc63